### PR TITLE
adding hdf5 files to installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ def main():
         # packages=find_packages(exclude=('test','data', 'docs')),
         packages=['ldds'],
         package_dir={'ldds': 'ldds'},
+        package_data={'ldds': ['pes_files/HenonHeiles_pes_data.hdf5', 'vector_field_files/Duffing_perturbed_vector_field_data.hdf5']},
 
         install_requires = requirements
     )


### PR DESCRIPTION
Fix to copy HDF5 files after installation under `build/lib/ldds/`